### PR TITLE
add ajax to create messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,9 +224,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -269,7 +266,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,10 +53,11 @@ $(function(){
       $('.chat-main__message-list').append(html);
       $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
       $('form')[0].reset();
-      $('.chat-main__message-form--submit-btn').prop('disabled', false);
     })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
+    })
+    .always(function(){
       $('.chat-main__message-form--submit-btn').prop('disabled', false);
     });
   })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,63 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+        `<div class="chat-main__message-list--message" data-message-id=${message.id}>
+          <div class="chat-main__message-list--upper-info">
+            <div class="chat-main__message-list--talker">
+              ${message.user_name}
+            </div>
+            <div class="chat-main__message-list--date">
+              ${message.created_at}
+            </div>
+          </div>
+          <p class="chat-main__message-list--message-text">
+            ${message.content}
+          </p>
+          <img class="chat-main__message-list--message-image" src=${message.image}>
+        </div>`
+      return html;
+    } else {
+      var html =
+        `<div class="chat-main__message-list--message" data-message-id=${message.id}>
+          <div class="chat-main__message-list--upper-info">
+            <div class="chat-main__message-list--talker">
+              ${message.user_name}
+            </div>
+            <div class="chat-main__message-list--date">
+              ${message.created_at}
+            </div>
+          </div>
+          <p class="chat-main__message-list--message-text">
+            ${message.content}
+          </p>
+        </div>`
+      return html;
+    };
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat-main__message-list').append(html);
+      $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.chat-main__message-form--submit-btn').prop('disabled', false);
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+      $('.chat-main__message-form--submit-btn').prop('disabled', false);
+    });
+  })
+});

--- a/app/assets/stylesheets/modules/_main_chat.scss
+++ b/app/assets/stylesheets/modules/_main_chat.scss
@@ -33,6 +33,7 @@
     height: calc(100vh - 190px);
     background-color: #fafafa;
     padding: 35px 40px;
+    overflow: scroll;
     &--message {
       margin-bottom: 46px;
     }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        # format.html { redirect_to group_messages_path, notice: "メッセージを送信しました" }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,8 +9,7 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      respond_to do |format|
-        # format.html { redirect_to group_messages_path, notice: "メッセージを送信しました" }
+      respond_to do |format｜
         format.json
       end
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,7 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      respond_to do |format｜
+      respond_to do |format|
         format.json
       end
     else

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# pull request
## What
Ajaxを使って、グループ内のメッセージ送信を非同期通信に修正。
overflowでページをスクロールできるように変更。
メッセージ送信を連続して行えるように修正。

## Why
処理を非同期にすることでなんどもページを更新するのを防ぐため。
メッセージが増えるとレイアウトが崩れてしまうのを防ぐため。
ページを更新しないと新しいメッセージを送信できなかった問題を解決するため。

## gif
https://gyazo.com/e2d8b796d1101adade35ce511a28a803